### PR TITLE
Turn off fontsize calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ yarn-error.log*
 # Editor directories and files
 .idea
 .vscode
+.vs
 *.suo
 *.ntvs*
 *.njsproj

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Making the component look like a pie chart is as simple as setting the `thicknes
 | `unit` | String | No | `'px'` | Unit to use for `size`. Can be any valid CSS unit. Use `%` to make the donut responsive. |
 | `thickness` | Number | No | `20` | Percent thickness of the donut ring relative to `size`. Can be any positive value between 0-100 (inclusive). Set this to 0 to draw a pie chart instead. |
 | `text` | String | No | &ndash; | Text to show in the middle of the donut. This can also be provided through the default slot. |
+| `textResize` | Boolean | No | true | Whether to automatically resize text based on width or not. |
 | `background` | String | No | `'#ffffff'` | Background color of the donut. In most cases, this should be the background color of the parent element. |
 | `foreground` | String | No | `'#eeeeee'` | Foreground color of the donut. This is the color that is shown for empty region of the donut ring. |
 | `start-angle` | Number | No | `0` | Angle measure in degrees where the first section should start. |

--- a/package.json
+++ b/package.json
@@ -5,13 +5,13 @@
   "author": "dumptyd <dumptyd2.0@gmail.com>",
   "homepage": "https://dumptyd.github.io/vue-css-donut-chart/",
   "scripts": {
-    "serve": "vue-cli-service serve",
-    "build": "yarn clear:babel-cache && MODE=site vue-cli-service build --modern --dest docs",
-    "lint": "vue-cli-service lint",
-    "build-lib": "yarn clear:babel-cache && vue-cli-service build --target lib --name vcdonut src/index.js",
+    "serve": "node ./node_modules/@vue/cli-service/bin/vue-cli-service.js serve",
+    "build": "yarn clear:babel-cache && MODE=site node ./node_modules/@vue/cli-service/bin/vue-cli-service.js build --modern --dest docs",
+    "lint": "node ./node_modules/@vue/cli-service/bin/vue-cli-service.js lint",
+    "build-lib": "yarn clear:babel-cache && node ./node_modules/@vue/cli-service/bin/vue-cli-service.js build --target lib --name vcdonut src/index.js",
     "clear:babel-cache": "rm -rf ./node_modules/.cache/babel-loader/*",
-    "test": "vue-cli-service test:unit",
-    "test:coverage": "vue-cli-service test:unit --coverage"
+    "test": "node ./node_modules/@vue/cli-service/bin/vue-cli-service.js test:unit",
+    "test:coverage": "node ./node_modules/@vue/cli-service/bin/vue-cli-service.js test:unit --coverage"
   },
   "main": "dist/vcdonut.umd.js",
   "module": "dist/vcdonut.common.js",

--- a/src/components/Donut.vue
+++ b/src/components/Donut.vue
@@ -50,6 +50,9 @@ export default {
     // text in the middle of the donut, this can also be passed using the default slot
     text: { type: String, default: null },
 
+    // text in the middle of the donut, this can also be passed using the default slot
+    textResize: { type: Boolean, default: true },
+
     // color to use for the middle of the donut
     // set this to `transparent` or `thickness` to 100 to make a pie chart instead
     background: { type: String, default: '#ffffff' },
@@ -187,6 +190,8 @@ export default {
       };
     },
     donutTextStyles() {
+      if (!this.textResize) return {};
+
       const { fontSize } = this;
       return { fontSize };
     }

--- a/tests/unit/donut.spec.js
+++ b/tests/unit/donut.spec.js
@@ -377,6 +377,29 @@ describe('Donut component', () => {
       expect(oldfontSize).not.toEqual(newfontSize);
     });
 
+    it('does not trigger font-size recalculation when the window is resized/zoomed if font-size recalculation is turned off', async () => {
+      const wrapper = shallowMount(Donut, { propsData: { size: 50, textResize: false } });
+      const { vm } = wrapper;
+
+      let clientWidth = 250;
+      jest.spyOn(vm.donutEl, 'clientWidth', 'get').mockImplementation(() => clientWidth);
+
+      // trigger recalcFontSize so it accesses `clientWidth` this time
+      wrapper.setProps({ unit: '%' });
+      await vm.$nextTick();
+
+      const oldDonutTextStyles = wrapper.vm.donutTextStyles;
+
+      // trigger resize and update the clientWidth
+      clientWidth = 350;
+      triggerResize();
+      await vm.$nextTick();
+
+      const newDonutTextStyles = vm.donutTextStyles;
+
+      expect(oldDonutTextStyles).toEqual(newDonutTextStyles);
+    });
+
     it('removes the resize listener from window when the component is destroyed', () => {
       const wrapper = shallowMount(Donut);
       const removeListener = jest.spyOn(window, 'removeEventListener');


### PR DESCRIPTION
See #20 which is part of this PR as well.

Adds support for turning of automatic font-size calculations (and turning of setting font-size at all). It's currently not easily possible to override the  font-size and set it to something fixed - this is now possible by turning off the automatic font-size calculations.