### PR TITLE
Hover events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ yarn-error.log*
 # Editor directories and files
 .idea
 .vscode
+.vs
 *.suo
 *.ntvs*
 *.njsproj

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Making the component look like a pie chart is as simple as setting the `thicknes
 | `section.value` | Number | **Yes** | &ndash; | Value of the section. The component determines what percent of the donut should be taken by a section based on this value and the `total` prop. Sum of all the sections' `value` should not exceed `total`, an error is thrown otherwise. |
 | `section.color` | String | Read description | Read description | Color of the section. The component comes with 24 predefined colors, so this property is optional if you have <= 24 sections without the `color` property. |
 | `section.label` | String | No | `'Section <section number>'` | Name of the section. This is used in the legend as well as the tooltip text of the section. |
+| `sectionHoverClass` | String | No | &ndash; | Class added to sections/legends on hover on that specific section/legend (cross-added) |
 
 
 #### Events

--- a/package.json
+++ b/package.json
@@ -5,13 +5,13 @@
   "author": "dumptyd <dumptyd2.0@gmail.com>",
   "homepage": "https://dumptyd.github.io/vue-css-donut-chart/",
   "scripts": {
-    "serve": "vue-cli-service serve",
-    "build": "yarn clear:babel-cache && MODE=site vue-cli-service build --modern --dest docs",
-    "lint": "vue-cli-service lint",
-    "build-lib": "yarn clear:babel-cache && vue-cli-service build --target lib --name vcdonut src/index.js",
+    "serve": "node ./node_modules/@vue/cli-service/bin/vue-cli-service.js serve",
+    "build": "yarn clear:babel-cache && MODE=site node ./node_modules/@vue/cli-service/bin/vue-cli-service.js build --modern --dest docs",
+    "lint": "node ./node_modules/@vue/cli-service/bin/vue-cli-service.js lint",
+    "build-lib": "yarn clear:babel-cache && node ./node_modules/@vue/cli-service/bin/vue-cli-service.js build --target lib --name vcdonut src/index.js",
     "clear:babel-cache": "rm -rf ./node_modules/.cache/babel-loader/*",
-    "test": "vue-cli-service test:unit",
-    "test:coverage": "vue-cli-service test:unit --coverage"
+    "test": "node ./node_modules/@vue/cli-service/bin/vue-cli-service.js test:unit",
+    "test:coverage": "node ./node_modules/@vue/cli-service/bin/vue-cli-service.js test:unit --coverage"
   },
   "main": "dist/vcdonut.umd.js",
   "module": "dist/vcdonut.common.js",

--- a/src/components/Donut.vue
+++ b/src/components/Donut.vue
@@ -17,7 +17,13 @@
 
   <slot name="legend">
     <div class="cdc-legend" v-if="hasLegend" :style="placementStyles.legend">
-      <span class="cdc-legend-item" :class="item.classes" v-for="(item, idx) in legend" :key="idx" :title="item.percent" @mouseenter="sectionLegendMouseEnter(idx)" @mouseleave="sectionLegendMouseLeave(idx)">
+      <span class="cdc-legend-item"
+            :class="item.classes"
+            v-for="(item, idx) in legend"
+            :key="idx"
+            :title="item.percent"
+            @mouseenter="sectionLegendMouseEnter(idx)"
+            @mouseleave="sectionLegendMouseLeave(idx)">
         <span class="cdc-legend-item-color" :style="item.styles"></span>
         <span>{{ item.label }}</span>
       </span>
@@ -134,12 +140,30 @@ export default {
             const remainingDegreesInCurrentSection = degreesInASection - consumedDegrees;
 
             sections.push(
-              { ...section, degree: remainingDegreesInCurrentSection, color, $section: section, hover: this.sectionHoverIndex === idx },
-              { ...section, degree: degree - remainingDegreesInCurrentSection, color, $section: section, hover: this.sectionHoverIndex === idx }
+              {
+                ...section,
+                degree: remainingDegreesInCurrentSection,
+                color,
+                $section: section,
+                hover: this.sectionHoverIndex === idx
+              },
+              {
+                ...section,
+                degree: degree - remainingDegreesInCurrentSection,
+                color,
+                $section: section,
+                hover: this.sectionHoverIndex === idx
+              }
             );
           }
           else {
-            sections.push({ ...section, degree, color, $section: section, hover: this.sectionHoverIndex === idx });
+            sections.push({
+              ...section,
+              degree,
+              color,
+              $section: section,
+              hover: this.sectionHoverIndex === idx
+            });
           }
 
           consumedDegrees += degree;

--- a/src/components/DonutSections.vue
+++ b/src/components/DonutSections.vue
@@ -3,7 +3,9 @@
   <div
     class="cdc-section" v-for="(section, idx) in donutSections"
     :key="idx" :class="section.className" :style="section.sectionStyles"
-    @click="emitClick(sections[idx])">
+    @click="emitClick(sections[idx])"
+    @mouseenter="emitMouseEnter(idx)"
+    @mouseleave="emitMouseLeave(idx)">
     <div class="cdc-filler" :style="section.fillerStyles" :title="section.label"></div>
   </div>
 </div>
@@ -52,7 +54,7 @@ export default {
         if (degreesConsumed === 180) offsetBy = 0;
         else offsetBy += section.degree;
 
-        return { label: section.label, className, fillerStyles, sectionStyles };
+        return { label: section.label, className: className + (section.hover ? ' ' + this.$parent.sectionHoverClass : ''), fillerStyles, sectionStyles };
       });
 
       return sections;
@@ -61,6 +63,12 @@ export default {
   methods: {
     emitClick(section) {
       this.$emit('section-click', section.$section);
+    },
+    emitMouseEnter(idx) {
+      this.$emit('mouseenter', idx);
+    },
+    emitMouseLeave(idx, $event) {
+      this.$emit('mouseleave', idx);
     }
   }
 };

--- a/src/components/DonutSections.vue
+++ b/src/components/DonutSections.vue
@@ -54,7 +54,12 @@ export default {
         if (degreesConsumed === 180) offsetBy = 0;
         else offsetBy += section.degree;
 
-        return { label: section.label, className: className + (section.hover ? ' ' + this.$parent.sectionHoverClass : ''), fillerStyles, sectionStyles };
+        return {
+          label: section.label,
+          className: className + (section.hover ? ` ${this.$parent.sectionHoverClass}` : ''),
+          fillerStyles,
+          sectionStyles
+        };
       });
 
       return sections;
@@ -67,7 +72,7 @@ export default {
     emitMouseEnter(idx) {
       this.$emit('mouseenter', idx);
     },
-    emitMouseLeave(idx, $event) {
+    emitMouseLeave(idx) {
       this.$emit('mouseleave', idx);
     }
   }

--- a/tests/unit/donut.spec.js
+++ b/tests/unit/donut.spec.js
@@ -292,6 +292,98 @@ describe('Donut component', () => {
     });
   });
 
+  describe.only('"sectionHoverClass" prop', () => {
+    it('section and legend get sectionHoverClass on section mouseenter', () => {
+      const sections = [10, 20, 30].map(value => ({ value }));
+      const wrapper = mount(Donut, { propsData: { sections, hasLegend: true, sectionHoverClass: 'abc' } });
+      
+      const sectionWrappers = wrapper.findAll(el.DONUT_SECTION);
+      const legendWrappers = wrapper.findAll(el.LEGEND_ITEM);
+
+      sections.forEach((section, idx) => {
+        sectionWrappers.at(idx).trigger('mouseenter');
+        expect(sectionWrappers.at(idx).classes()).toContain('abc');
+        expect(legendWrappers.at(idx).classes()).toContain('abc');
+      });
+    });
+
+    it('no other section or legend get sectionHoverClass on section mouseenter', () => {
+      const sections = [10, 20, 30].map(value => ({ value }));
+      const wrapper = mount(Donut, { propsData: { sections, hasLegend: true, sectionHoverClass: 'abc' } });
+
+      const sectionWrappers = wrapper.findAll(el.DONUT_SECTION);
+      const legendWrappers = wrapper.findAll(el.LEGEND_ITEM);
+
+      sections.forEach((section, idx) => {
+        sectionWrappers.at(idx).trigger('mouseenter');
+        sections.forEach((section, index) => {
+          if (index !== idx) expect(sectionWrappers.at(index).classes()).not.toContain('abc');
+          if (index !== idx) expect(legendWrappers.at(index).classes()).not.toContain('abc');
+        });
+      });
+    });
+
+    it('section and legend get sectionHoverClass removed on section mouseleave', () => {
+      const sections = [10, 20, 30].map(value => ({ value }));
+      const wrapper = mount(Donut, { propsData: { sections, hasLegend: true, sectionHoverClass: 'abc' } });
+
+      const sectionWrappers = wrapper.findAll(el.DONUT_SECTION);
+      const legendWrappers = wrapper.findAll(el.LEGEND_ITEM);
+
+      sections.forEach((section, idx) => {
+        sectionWrappers.at(idx).trigger('mouseenter');
+        sectionWrappers.at(idx).trigger('mouseleave');
+        expect(sectionWrappers.at(idx).classes()).not.toContain('abc');
+        expect(legendWrappers.at(idx).classes()).not.toContain('abc');
+      });
+    });
+
+    it('section and legend get sectionHoverClass on legend mouseenter', () => {
+      const sections = [10, 20, 30].map(value => ({ value }));
+      const wrapper = mount(Donut, { propsData: { sections, hasLegend: true, sectionHoverClass: 'abc' } });
+
+      const sectionWrappers = wrapper.findAll(el.DONUT_SECTION);
+      const legendWrappers = wrapper.findAll(el.LEGEND_ITEM);
+
+      sections.forEach((section, idx) => {
+        legendWrappers.at(idx).trigger('mouseenter');
+        expect(sectionWrappers.at(idx).classes()).toContain('abc');
+        expect(legendWrappers.at(idx).classes()).toContain('abc');
+      });
+    });
+
+    it('no other section or legend get sectionHoverClass on legend mouseenter', () => {
+      const sections = [10, 20, 30].map(value => ({ value }));
+      const wrapper = mount(Donut, { propsData: { sections, hasLegend: true, sectionHoverClass: 'abc' } });
+
+      const sectionWrappers = wrapper.findAll(el.DONUT_SECTION);
+      const legendWrappers = wrapper.findAll(el.LEGEND_ITEM);
+
+      sections.forEach((section, idx) => {
+        legendWrappers.at(idx).trigger('mouseenter');
+        sections.forEach((section, index) => {
+          if (index !== idx) expect(sectionWrappers.at(index).classes()).not.toContain('abc');
+          if (index !== idx) expect(legendWrappers.at(index).classes()).not.toContain('abc');
+        });
+      });
+    });
+
+    it('section and legend get sectionHoverClass removed on legend mouseleave', () => {
+      const sections = [10, 20, 30].map(value => ({ value }));
+      const wrapper = mount(Donut, { propsData: { sections, hasLegend: true, sectionHoverClass: 'abc' } });
+
+      const sectionWrappers = wrapper.findAll(el.DONUT_SECTION);
+      const legendWrappers = wrapper.findAll(el.LEGEND_ITEM);
+
+      sections.forEach((section, idx) => {
+        legendWrappers.at(idx).trigger('mouseenter');
+        legendWrappers.at(idx).trigger('mouseleave');
+        expect(sectionWrappers.at(idx).classes()).not.toContain('abc');
+        expect(legendWrappers.at(idx).classes()).not.toContain('abc');
+      });
+    });
+  });
+
   describe('"start-angle" prop', () => {
     it('renders the sections with correct "start-angle" offset', () => {
       const sections = [10, 20, 30].map(value => ({ value }));

--- a/tests/unit/donut.spec.js
+++ b/tests/unit/donut.spec.js
@@ -296,7 +296,7 @@ describe('Donut component', () => {
     it('section and legend get sectionHoverClass on section mouseenter', () => {
       const sections = [10, 20, 30].map(value => ({ value }));
       const wrapper = mount(Donut, { propsData: { sections, hasLegend: true, sectionHoverClass: 'abc' } });
-      
+
       const sectionWrappers = wrapper.findAll(el.DONUT_SECTION);
       const legendWrappers = wrapper.findAll(el.LEGEND_ITEM);
 
@@ -316,7 +316,7 @@ describe('Donut component', () => {
 
       sections.forEach((section, idx) => {
         sectionWrappers.at(idx).trigger('mouseenter');
-        sections.forEach((section, index) => {
+        sections.forEach((innerSection, index) => {
           if (index !== idx) expect(sectionWrappers.at(index).classes()).not.toContain('abc');
           if (index !== idx) expect(legendWrappers.at(index).classes()).not.toContain('abc');
         });
@@ -361,7 +361,7 @@ describe('Donut component', () => {
 
       sections.forEach((section, idx) => {
         legendWrappers.at(idx).trigger('mouseenter');
-        sections.forEach((section, index) => {
+        sections.forEach((innerSection, index) => {
           if (index !== idx) expect(sectionWrappers.at(index).classes()).not.toContain('abc');
           if (index !== idx) expect(legendWrappers.at(index).classes()).not.toContain('abc');
         });

--- a/tests/unit/donut.spec.js
+++ b/tests/unit/donut.spec.js
@@ -292,7 +292,7 @@ describe('Donut component', () => {
     });
   });
 
-  describe.only('"sectionHoverClass" prop', () => {
+  describe('"sectionHoverClass" prop', () => {
     it('section and legend get sectionHoverClass on section mouseenter', () => {
       const sections = [10, 20, 30].map(value => ({ value }));
       const wrapper = mount(Donut, { propsData: { sections, hasLegend: true, sectionHoverClass: 'abc' } });


### PR DESCRIPTION
See #20 which is part of this PR as well.

Adds support for adding a class to legends and sections on hover - regardless if hovering either the legend or the section (both will get the class anyway). This makes it possible to style those elements differently on hover.

Also makes it possible to handle the case specified in #19  - although in a way that is not super nice. Basically, it's possible to watch the sectionHoverIndex data property. This property is -1 when nothing is hovered, and changes to the index of the section that is hovered whenever any hover of any section is made by the user.