### PR TITLE
Fix issue with extra donut-section for the last item in sections

### DIFF
--- a/src/components/Donut.vue
+++ b/src/components/Donut.vue
@@ -123,7 +123,8 @@ export default {
         const color = section.color || defaultColors[currentDefaultColorIdx++];
 
         degreeArr.forEach(degree => {
-          const consumedWithCurrent = consumedDegrees + degree;
+          // +(n).toFixed(2) is a fix for Floating-Point Problems
+          const consumedWithCurrent = +(consumedDegrees + degree).toFixed(2);
           if (consumedWithCurrent > degreesInASection) {
             const remainingDegreesInCurrentSection = degreesInASection - consumedDegrees;
 


### PR DESCRIPTION
Sometimes consumedWithCurrent=180.00000000003 because of floating-point problems. It causes an issue with the redundant line on the bottom of the chart