### PR TITLE
Add support for listening to mouse events on sections and make it easier to add support for other section events

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,7 @@ This will create a donut with 2 sections that take up 25% each.
     has-legend legend-placement="top"
     :sections="sections" :total="100"
     :start-angle="0"
-    @section-click="handleSectionClick"
-  >
+    @section-click="handleSectionClick">
     <h1>75%</h1>
   </vc-donut>
 </template>
@@ -158,13 +157,15 @@ This will create a donut with 2 sections that take up 25% each.
       };
     },
     methods: {
-      handleSectionClick(section) {
+      handleSectionClick(section, event) {
         console.log(`${section.label} clicked.`);
       }
     }
   };
 </script>
 ```
+
+For brevity, only the `section-click` event is demonstrated in the above example. You can use all the other `section-*` events the same way.
 
 #### Using the component as a pie chart
 
@@ -205,15 +206,22 @@ Making the component look like a pie chart is as simple as setting the `thicknes
 
 #### Events
 
+All the `section-*` events are called with the `section` object on which the event occurred and the native `Event` object as arguments respectively. Consider adding a custom property (eg: `name`) to the `section` objects to uniquely identify them.
+
 | Event | Parameter | Description |
 | ---------- | ------------ | ----------- |
-| `section-click` | `section` object | Emitted when a section is clicked. `section` object of the clicked section is passed as an argument. Consider adding a custom property (eg: `name`) to the `section` objects to uniquely identify them. |
+| `section-click` | `section`, `event` | Emitted when a section is clicked. |
+| `section-mouseenter` | `section`, `event` | Emitted when the `mouseenter` event occurs on a section. |
+| `section-mouseleave` | `section`, `event` | Emitted when the `mouseleave` event occurs on a section. |
+| `section-mouseover` | `section`, `event` | Emitted when the `mouseover` event occurs on a section. |
+| `section-mouseout` | `section`, `event` | Emitted when the `mouseout` event occurs on a section. |
+| `section-mousemove` | `section`, `event` | Emitted when the `mousemove` event occurs on a section. |
 
 #### Slots
 
 | Slot | Description |
 | ---- | ----------- |
-| default slot | `section` object | If you want more control over the content of the chart, default slot can be used instead of the `text` prop. |
+| default slot | If you want more control over the content of the chart, default slot can be used instead of the `text` prop. |
 | `legend` | Slot for plugging in your own legend. |
 
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Making the component look like a pie chart is as simple as setting the `thicknes
 
 #### Events
 
-All the `section-*` events are called with the `section` object on which the event occurred and the native `Event` object as arguments respectively. Consider adding a custom property (eg: `name`) to the `section` objects to uniquely identify them.
+All the `section-*` listeners are called with the `section` object on which the event occurred and the native `Event` object as arguments respectively. Consider adding a custom property (eg: `name`) to the `section` objects to uniquely identify them.
 
 | Event | Parameter | Description |
 | ---------- | ------------ | ----------- |

--- a/src/components/Donut.vue
+++ b/src/components/Donut.vue
@@ -2,9 +2,9 @@
 <div class="cdc-container" :style="placementStyles.container">
   <div class="cdc" ref="donut" :style="donutStyles">
     <donut-sections
+      v-on="sectionListeners"
       :sections="donutSections"
-      :start-angle="startAngle"
-      @section-click="emitSectionClick">
+      :start-angle="startAngle">
     </donut-sections>
     <div class="cdc-overlay" :style="overlayStyles">
       <div class="cdc-text" :style="donutTextStyles">
@@ -25,6 +25,7 @@
 </template>
 
 <script>
+import { nativeSectionEvents } from '../utils/events';
 import defaultColors from '../utils/colors';
 import { placement, placementStyles, sectionValidator } from '../utils/misc';
 import DonutSections from './DonutSections.vue';
@@ -189,6 +190,12 @@ export default {
     donutTextStyles() {
       const { fontSize } = this;
       return { fontSize };
+    },
+    sectionListeners() {
+      return nativeSectionEvents.reduce((acc, { sectionEventName }) => ({
+        ...acc,
+        [sectionEventName]: (...args) => this.emitSectionEvent(sectionEventName, ...args)
+      }), {});
     }
   },
   methods: {
@@ -206,8 +213,8 @@ export default {
         this.fontSize = widthInPx ? `${(widthInPx * scaleDownBy).toFixed(2)}px` : '1em';
       });
     },
-    emitSectionClick(section) {
-      this.$emit('section-click', section);
+    emitSectionEvent(sectionEventName, ...args) {
+      this.$emit(sectionEventName, ...args);
     }
   },
   mounted() {

--- a/src/components/DonutSections.vue
+++ b/src/components/DonutSections.vue
@@ -1,15 +1,15 @@
 <template>
 <div class="cdc-sections" :style="containerStyles">
   <div
-    class="cdc-section" v-for="(section, idx) in donutSections"
-    :key="idx" :class="section.className" :style="section.sectionStyles"
-    @click="emitClick(sections[idx])">
+    v-for="(section, idx) in donutSections" v-on="section.listeners" :key="idx"
+    class="cdc-section" :class="section.className" :style="section.sectionStyles">
     <div class="cdc-filler" :style="section.fillerStyles" :title="section.label"></div>
   </div>
 </div>
 </template>
 
 <script>
+import { nativeSectionEvents } from '../utils/events';
 import { defaultColor } from '../utils/misc';
 
 const sectionClass = {
@@ -52,15 +52,27 @@ export default {
         if (degreesConsumed === 180) offsetBy = 0;
         else offsetBy += section.degree;
 
-        return { label: section.label, className, fillerStyles, sectionStyles };
+        const listeners = nativeSectionEvents.reduce((acc, { nativeEventName, sectionEventName }) => ({
+          ...acc,
+          [nativeEventName]: event => this.emitEvent(sectionEventName, section, event)
+        }), {});
+
+        return {
+          label: section.label,
+          className,
+          fillerStyles,
+          sectionStyles,
+          listeners
+        };
       });
 
       return sections;
     }
   },
   methods: {
-    emitClick(section) {
-      this.$emit('section-click', section.$section);
+    emitEvent(sectionEventName, section, event) {
+      if (section.value === 0) return;
+      this.$emit(sectionEventName, section.$section, event);
     }
   }
 };

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -88,6 +88,13 @@ footer {
   margin: .5rem .5rem 0;
 }
 
+.note {
+  margin-top: .5rem;
+  padding: .5rem .75rem;
+  font-size: .9rem;
+  border-left: 5px solid deepskyblue;
+}
+
 label { margin-right: .75rem; }
 input, select, textarea, button {
   background-color: inherit;

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -1,0 +1,11 @@
+export const nativeSectionEvents = [
+  'click',
+  'mouseenter',
+  'mouseleave',
+  'mouseover',
+  'mouseout',
+  'mousemove'
+].map(nativeEventName => ({
+  nativeEventName,
+  sectionEventName: `section-${nativeEventName}`
+}));


### PR DESCRIPTION
This PR implements the following changes:

### Library

- Adds the following new events (#19)
  - `section-mouseenter`
  - `section-mouseleave`
  - `section-mouseover`
  - `section-mouseout`
  - `section-mousemove`
- All the `section-*` events are now emitted with the native event object as the second parameter.

### Documentation

- Add documentation for new events.
- Fix some minor formatting issues.

### Demo

- Demo page now has a section for trying out events.
- Checkbox labels can now be clicked to toggle the value (as they should). I didn't know checkbox labels' `for` attribute mapped to `id`. 

### Implementation

Implementation wise, this PR makes it very easy to add support for new native section events. The process would be as simple as updating the `utils/events.js` file with the event name and the event would be supported on the section. An entry for the event would be made on the demo page as well. The coverage wouldn't drop either because tests are generated dynamically for these events. Of course the README would have to be updated too.
