### PR TITLE
1.2.0: New events, bug fixes, demo site updates, etc.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -53,7 +53,7 @@
     ],
     "import/no-named-as-default": "off",
     "no-new": "off",
-    "object-property-newline": "warn",
+    "object-property-newline": "off",
     "import/prefer-default-export": "off",
     "arrow-parens": "off",
     "arrow-body-style": "off",
@@ -66,7 +66,8 @@
         "consistent": true
       }
     ],
-    "valid-typeof": "off"
+    "valid-typeof": "off",
+    "operator-linebreak": ["warn", "after"]
   },
   "parserOptions": {
     "parser": "babel-eslint"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.0]
+
+### Added
+
+- Adds the following new events (#26)
+  - `section-mouseenter`
+  - `section-mouseleave`
+  - `section-mouseover`
+  - `section-mouseout`
+  - `section-mousemove`
+- All the `section-*` events are now emitted with the native `Event` object as the second parameter.
+
+### Fixed
+
+- A floating-point arithmetic issue was causing the section rendering logic to behave in unexpected ways. This has been fixed. (#23)
+- Another floating-point arithmetic issue was causing the `total` prop's validator to incorrectly flag valid values. This has been fixed as well. (#24)
+
+### Other changes
+
+- Demo page now has a section dedicated for testing all the exposed events.
+- Documentation has been updated with new events.
+
 ## [1.1.6]
 ## [1.1.5]
 

--- a/README.md
+++ b/README.md
@@ -141,8 +141,7 @@ This will create a donut with 2 sections that take up 25% each.
     has-legend legend-placement="top"
     :sections="sections" :total="100"
     :start-angle="0"
-    @section-click="handleSectionClick"
-  >
+    @section-click="handleSectionClick">
     <h1>75%</h1>
   </vc-donut>
 </template>
@@ -158,13 +157,15 @@ This will create a donut with 2 sections that take up 25% each.
       };
     },
     methods: {
-      handleSectionClick(section) {
+      handleSectionClick(section, event) {
         console.log(`${section.label} clicked.`);
       }
     }
   };
 </script>
 ```
+
+For brevity, only the `section-click` event is demonstrated in the above example. You can use all the other `section-*` events the same way.
 
 #### Using the component as a pie chart
 
@@ -205,15 +206,22 @@ Making the component look like a pie chart is as simple as setting the `thicknes
 
 #### Events
 
+All the `section-*` events are called with the `section` object on which the event occurred and the native `Event` object as arguments respectively. Consider adding a custom property (eg: `name`) to the `section` objects to uniquely identify them.
+
 | Event | Parameter | Description |
 | ---------- | ------------ | ----------- |
-| `section-click` | `section` object | Emitted when a section is clicked. `section` object of the clicked section is passed as an argument. Consider adding a custom property (eg: `name`) to the `section` objects to uniquely identify them. |
+| `section-click` | `section`, `event` | Emitted when a section is clicked. |
+| `section-mouseenter` | `section`, `event` | Emitted when the `mouseenter` event occurs on a section. |
+| `section-mouseleave` | `section`, `event` | Emitted when the `mouseleave` event occurs on a section. |
+| `section-mouseover` | `section`, `event` | Emitted when the `mouseover` event occurs on a section. |
+| `section-mouseout` | `section`, `event` | Emitted when the `mouseout` event occurs on a section. |
+| `section-mousemove` | `section`, `event` | Emitted when the `mousemove` event occurs on a section. |
 
 #### Slots
 
 | Slot | Description |
 | ---- | ----------- |
-| default slot | `section` object | If you want more control over the content of the chart, default slot can be used instead of the `text` prop. |
+| default slot | If you want more control over the content of the chart, default slot can be used instead of the `text` prop. |
 | `legend` | Slot for plugging in your own legend. |
 
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Making the component look like a pie chart is as simple as setting the `thicknes
 
 #### Events
 
-All the `section-*` events are called with the `section` object on which the event occurred and the native `Event` object as arguments respectively. Consider adding a custom property (eg: `name`) to the `section` objects to uniquely identify them.
+All the `section-*` listeners are called with the `section` object on which the event occurred and the native `Event` object as arguments respectively. Consider adding a custom property (eg: `name`) to the `section` objects to uniquely identify them.
 
 | Event | Parameter | Description |
 | ---------- | ------------ | ----------- |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-css-donut-chart",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "description": "Lightweight Vue component for drawing pure CSS donut charts",
   "author": "dumptyd <dumptyd2.0@gmail.com>",
   "homepage": "https://dumptyd.github.io/vue-css-donut-chart/",

--- a/src/components/Donut.vue
+++ b/src/components/Donut.vue
@@ -99,7 +99,7 @@ export default {
   },
   computed: {
     donutSections() {
-      const valueTotal = this.sections.reduce((a, c) => a + c.value, 0);
+      const valueTotal = +(this.sections.reduce((a, c) => a + c.value, 0)).toFixed(2);
       if (valueTotal > this.total) {
         const err = `Sum of all the sections' values (${valueTotal}) should not exceed \`total\` (${this.total})`;
         throw new Error(err);

--- a/src/components/Donut.vue
+++ b/src/components/Donut.vue
@@ -123,7 +123,8 @@ export default {
         const color = section.color || defaultColors[currentDefaultColorIdx++];
 
         degreeArr.forEach(degree => {
-          const consumedWithCurrent = consumedDegrees + degree;
+          // +(n).toFixed(2) is a fix for Floating-Point Problems
+          const consumedWithCurrent = +(consumedDegrees + degree).toFixed(2);
           if (consumedWithCurrent > degreesInASection) {
             const remainingDegreesInCurrentSection = degreesInASection - consumedDegrees;
 

--- a/src/components/Donut.vue
+++ b/src/components/Donut.vue
@@ -100,7 +100,10 @@ export default {
   },
   computed: {
     donutSections() {
-      const valueTotal = +(this.sections.reduce((a, c) => a + c.value, 0)).toFixed(2);
+      let valueTotal = this.sections.reduce((a, c) => a + c.value, 0);
+      if (typeof valueTotal !== 'number') return [];
+      valueTotal = Number(valueTotal.toFixed(2));
+
       if (valueTotal > this.total) {
         const err = `Sum of all the sections' values (${valueTotal}) should not exceed \`total\` (${this.total})`;
         throw new Error(err);
@@ -124,8 +127,8 @@ export default {
         const color = section.color || defaultColors[currentDefaultColorIdx++];
 
         degreeArr.forEach(degree => {
-          // +(n).toFixed(2) is a fix for Floating-Point Problems
-          const consumedWithCurrent = +(consumedDegrees + degree).toFixed(2);
+          // limit to 2 decimal digits to avoid floating point arithmetic issues
+          const consumedWithCurrent = Number((consumedDegrees + degree).toFixed(2));
           if (consumedWithCurrent > degreesInASection) {
             const remainingDegreesInCurrentSection = degreesInASection - consumedDegrees;
 

--- a/src/components/Donut.vue
+++ b/src/components/Donut.vue
@@ -2,9 +2,9 @@
 <div class="cdc-container" :style="placementStyles.container">
   <div class="cdc" ref="donut" :style="donutStyles">
     <donut-sections
+      v-on="sectionListeners"
       :sections="donutSections"
-      :start-angle="startAngle"
-      @section-click="emitSectionClick">
+      :start-angle="startAngle">
     </donut-sections>
     <div class="cdc-overlay" :style="overlayStyles">
       <div class="cdc-text" :style="donutTextStyles">
@@ -25,6 +25,7 @@
 </template>
 
 <script>
+import { nativeSectionEvents } from '../utils/events';
 import defaultColors from '../utils/colors';
 import { placement, placementStyles, sectionValidator } from '../utils/misc';
 import DonutSections from './DonutSections.vue';
@@ -189,6 +190,12 @@ export default {
     donutTextStyles() {
       const { fontSize } = this;
       return { fontSize };
+    },
+    sectionListeners() {
+      return nativeSectionEvents.reduce((acc, { sectionEventName }) => ({
+        ...acc,
+        [sectionEventName]: (...args) => this.emitSectionEvent(sectionEventName, ...args)
+      }), {});
     }
   },
   methods: {
@@ -206,8 +213,8 @@ export default {
         this.fontSize = widthInPx ? `${(widthInPx * scaleDownBy).toFixed(2)}px` : '1em';
       });
     },
-    emitSectionClick(section) {
-      this.$emit('section-click', section);
+    emitSectionEvent(sectionEventName, ...args) {
+      this.$emit(sectionEventName, ...args);
     }
   },
   mounted() {

--- a/src/components/DonutSections.vue
+++ b/src/components/DonutSections.vue
@@ -1,15 +1,15 @@
 <template>
 <div class="cdc-sections" :style="containerStyles">
   <div
-    class="cdc-section" v-for="(section, idx) in donutSections"
-    :key="idx" :class="section.className" :style="section.sectionStyles"
-    @click="emitClick(sections[idx])">
+    v-for="(section, idx) in donutSections" v-on="section.listeners" :key="idx"
+    class="cdc-section" :class="section.className" :style="section.sectionStyles">
     <div class="cdc-filler" :style="section.fillerStyles" :title="section.label"></div>
   </div>
 </div>
 </template>
 
 <script>
+import { nativeSectionEvents } from '../utils/events';
 import { defaultColor } from '../utils/misc';
 
 const sectionClass = {
@@ -52,15 +52,27 @@ export default {
         if (degreesConsumed === 180) offsetBy = 0;
         else offsetBy += section.degree;
 
-        return { label: section.label, className, fillerStyles, sectionStyles };
+        const listeners = nativeSectionEvents.reduce((acc, { nativeEventName, sectionEventName }) => ({
+          ...acc,
+          [nativeEventName]: event => this.emitEvent(sectionEventName, section, event)
+        }), {});
+
+        return {
+          label: section.label,
+          className,
+          fillerStyles,
+          sectionStyles,
+          listeners
+        };
       });
 
       return sections;
     }
   },
   methods: {
-    emitClick(section) {
-      this.$emit('section-click', section.$section);
+    emitEvent(sectionEventName, section, event) {
+      if (section.value === 0) return;
+      this.$emit(sectionEventName, section.$section, event);
     }
   }
 };

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -103,6 +103,10 @@ input, select, textarea, button {
   border-radius: 5px;
   display: inline-block;
 }
+input:invalid, select:invalid, textarea:invalid {
+  box-shadow: 0 0 10px 2px tomato;
+  z-index: 1;
+}
 input[type=color] {
   height: 2.5rem;
   padding: 0;

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -88,6 +88,13 @@ footer {
   margin: .5rem .5rem 0;
 }
 
+.note {
+  margin-top: .5rem;
+  padding: .5rem .75rem;
+  font-size: .9rem;
+  border-left: 5px solid deepskyblue;
+}
+
 label { margin-right: .75rem; }
 input, select, textarea, button {
   background-color: inherit;

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -1,0 +1,11 @@
+export const nativeSectionEvents = [
+  'click',
+  'mouseenter',
+  'mouseleave',
+  'mouseover',
+  'mouseout',
+  'mousemove'
+].map(nativeEventName => ({
+  nativeEventName,
+  sectionEventName: `section-${nativeEventName}`
+}));

--- a/tests/unit/donut.spec.js
+++ b/tests/unit/donut.spec.js
@@ -198,6 +198,25 @@ describe('Donut component', () => {
       expect(sectionFillerWrappers.at(1).attributes('title')).toBe(sections[1].label);
       expect(sectionFillerWrappers.at(2).attributes('title')).toBeFalsy(); // no default title
     });
+
+    it('does not run into error when section.value is not of number type', () => {
+      const spy = jest.spyOn(global.console, 'error').mockImplementation(() => {});
+      const sections = [{ value: 10 }, { value: '' }];
+
+      let error = false;
+      try {
+        shallowMount(Donut, { propsData: { sections } });
+      }
+      catch (err) {
+        error = err;
+      }
+      finally {
+        expect(error).toBeFalsy();
+        spy.mockRestore();
+        // eslint-disable-next-line no-console
+        if (error) console.error(error);
+      }
+    });
   });
 
   describe('"total" prop', () => {

--- a/tests/unit/donut.spec.js
+++ b/tests/unit/donut.spec.js
@@ -120,7 +120,7 @@ describe('Donut component', () => {
   });
 
   describe('"sections" prop', () => {
-    it('renders the proper number of sections based on the section prop', () => {
+    it('renders correct number of sections based on the sections prop', () => {
       let sections = [
         { value: 25 },
         { value: 25 },
@@ -152,6 +152,20 @@ describe('Donut component', () => {
       sectionWrappers = wrapper.findAll(el.DONUT_SECTION);
       // since one section takes up more than 180 degrees, it should be split into 2
       expect(sectionWrappers).toHaveLength(sections.length + 1);
+    });
+
+    it('renders correct number of sections while accounting for floating-point arithmetic issues', () => {
+      // when using these values for sections and size, the component used to render 6 sections
+      // because of floating point issues. That should never happen - the component should at
+      // maximum have `sections.length + 1` sections.
+      const [fpaValues, fpaSize] = [[33, 33, 33, 1], 201];
+      const sections = fpaValues.map(value => ({ value }));
+
+      const wrapper = mount(Donut, { propsData: { sections, size: fpaSize } });
+      const sectionWrappers = wrapper.findAll(el.DONUT_SECTION);
+
+      // it should have 5 sections since the second 33 would get split into two sections
+      expect(sectionWrappers).toHaveLength(5);
     });
 
     // eslint-disable-next-line max-len
@@ -218,6 +232,23 @@ describe('Donut component', () => {
       finally {
         expect(errorThrown).toBe(true);
         spy.mockRestore();
+      }
+    });
+
+    it('accounts for floating-point arithmetic issues before throwing an error', () => {
+      // when using these values in this order, validation logic used to throw an error
+      const fpaValues = [8.2, 34.97, 30.6, 26.23];
+      const [total, sections] = [100, fpaValues.map(value => ({ value }))];
+
+      let errorThrown = false;
+      try {
+        shallowMount(Donut, { propsData: { total, sections } });
+      }
+      catch (error) {
+        errorThrown = true;
+      }
+      finally {
+        expect(errorThrown).toBe(false);
       }
     });
   });


### PR DESCRIPTION
This PR implements the following changes:

### Library

- Adds the following new events (#19)
  - `section-mouseenter`
  - `section-mouseleave`
  - `section-mouseover`
  - `section-mouseout`
  - `section-mousemove`
- All the `section-*` events are now emitted with the native event object as the second parameter.
- A couple floating point issues have been fixed.

### Documentation

- Add documentation for new events.
- Fix some minor formatting issues.

### Demo

- Demo page now has a section for trying out events.
- Checkbox labels can now be clicked to toggle the value (as they should). I didn't know checkbox labels' `for` attribute mapped to `id`.
- Fields have better validations now.

### Implementation

Implementation wise, this PR makes it very easy to add support for new native section events. The process would be as simple as updating the `utils/events.js` file with the event name and the event would be supported on the section. An entry for the event would be made on the demo page as well. The coverage wouldn't drop either because tests are generated dynamically for these events. Of course the README would have to be updated too.
