### PR TITLE
1.3.0: Add a prop to disable automatic font size recalculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 - `auto-adjust-text-size` prop is here! The prop can be set to `false` to disable the font size recalculation behavior.
 
-
 ### Other changes
 
 - Demo page now has an option to test `auto-adjust-text-size` prop.
-- Minor refactoring.
 
 ## [1.2.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.0]
+
+### Added
+- `auto-adjust-text-size` prop is here! The prop can be set to `false` to disable the font size recalculation behavior.
+
+
+### Other changes
+
+- Demo page now has an option to test `auto-adjust-text-size` prop.
+- Minor refactoring.
+
 ## [1.2.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ This will create a donut with 2 sections that take up 25% each.
     :size="200" unit="px" :thickness="30"
     has-legend legend-placement="top"
     :sections="sections" :total="100"
-    :start-angle="0"
+    :start-angle="0" :auto-adjust-text-size="true"
     @section-click="handleSectionClick">
     <h1>75%</h1>
   </vc-donut>
@@ -198,6 +198,7 @@ Making the component look like a pie chart is as simple as setting the `thicknes
 | `total` | Number | No | `100` | Total for calculating the percentage for each section. |
 | `has-legend` | Boolean | No | `false` | Whether the donut should have a legend. |
 | `legend-placement` | String | No | `'bottom'` | Where the legend should be placed. Valid values are `top`, `right`, `bottom` and `left`. Doesn't have an effect if `has-legend` is not true. |
+| `auto-adjust-text-size` | Boolean | No | `true` | Whether the font-size of the donut content is calculated automatically to fit the available space. |
 | `sections` | Array<section> | No | `[]` | An array of objects. Each object in the array represents a section. |
 | `section.value` | Number | **Yes** | &ndash; | Value of the section. The component determines what percent of the donut should be taken by a section based on this value and the `total` prop. Sum of all the sections' `value` should not exceed `total`, an error is thrown otherwise. |
 | `section.color` | String | Read description | Read description | Color of the section. The component comes with 24 predefined colors, so this property is optional if you have <= 24 sections without the `color` property. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-css-donut-chart",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Lightweight Vue component for drawing pure CSS donut charts",
   "author": "dumptyd <dumptyd2.0@gmail.com>",
   "homepage": "https://dumptyd.github.io/vue-css-donut-chart/",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "module": "dist/vcdonut.common.js",
   "unpkg": "dist/vcdonut.umd.min.js",
   "dependencies": {
-    "vue": "^2.5.17"
+    "vue": "^2.6.11"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^3.0.3",
@@ -30,7 +30,7 @@
     "dev": "^0.1.3",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.14.0",
-    "vue-template-compiler": "^2.5.17"
+    "vue-template-compiler": "^2.6.11"
   },
   "postcss": {
     "plugins": {

--- a/src/components/Donut.vue
+++ b/src/components/Donut.vue
@@ -210,7 +210,7 @@ export default {
     }
   },
   methods: {
-    async recalcFontSize() {
+    recalcFontSize() {
       if (!this.autoAdjustTextSize) {
         this.fontSize = '1em';
         return;
@@ -219,14 +219,15 @@ export default {
       const scaleDownBy = 0.08;
       let widthInPx = this.size;
 
-      await this.$nextTick();
-      if (this.unit !== 'px') {
-        /* istanbul ignore else */
-        if (this.donutEl) widthInPx = this.donutEl.clientWidth;
-        else widthInPx = null;
-      }
+      this.$nextTick(() => {
+        if (this.unit !== 'px') {
+          /* istanbul ignore else */
+          if (this.donutEl) widthInPx = this.donutEl.clientWidth;
+          else widthInPx = null;
+        }
 
-      this.fontSize = widthInPx ? `${(widthInPx * scaleDownBy).toFixed(2)}px` : '1em';
+        this.fontSize = widthInPx ? `${(widthInPx * scaleDownBy).toFixed(2)}px` : '1em';
+      });
     },
     emitSectionEvent(sectionEventName, ...args) {
       this.$emit(sectionEventName, ...args);

--- a/src/components/Donut.vue
+++ b/src/components/Donut.vue
@@ -51,6 +51,8 @@ export default {
     // text in the middle of the donut, this can also be passed using the default slot
     text: { type: String, default: null },
 
+    autoAdjustTextSize: { type: Boolean, default: true },
+
     // color to use for the middle of the donut
     // set this to `transparent` or `thickness` to 100 to make a pie chart instead
     background: { type: String, default: '#ffffff' },
@@ -83,6 +85,11 @@ export default {
     startAngle: { type: Number, default: 0 }
   },
   watch: {
+    autoAdjustTextSize(val) {
+      if (val) window.addEventListener('resize', this.resizeListener);
+      else window.removeEventListener('resize', this.resizeListener);
+      this.recalcFontSize();
+    },
     size() {
       this.recalcFontSize();
     },
@@ -203,31 +210,38 @@ export default {
     }
   },
   methods: {
-    recalcFontSize() {
+    async recalcFontSize() {
+      if (!this.autoAdjustTextSize) {
+        this.fontSize = '1em';
+        return;
+      }
+
       const scaleDownBy = 0.08;
       let widthInPx = this.size;
 
-      this.$nextTick(() => {
-        if (this.unit !== 'px') {
-          /* istanbul ignore else */
-          if (this.donutEl) widthInPx = this.donutEl.clientWidth;
-          else widthInPx = null;
-        }
+      await this.$nextTick();
+      if (this.unit !== 'px') {
+        /* istanbul ignore else */
+        if (this.donutEl) widthInPx = this.donutEl.clientWidth;
+        else widthInPx = null;
+      }
 
-        this.fontSize = widthInPx ? `${(widthInPx * scaleDownBy).toFixed(2)}px` : '1em';
-      });
+      this.fontSize = widthInPx ? `${(widthInPx * scaleDownBy).toFixed(2)}px` : '1em';
     },
     emitSectionEvent(sectionEventName, ...args) {
       this.$emit(sectionEventName, ...args);
     }
   },
+  created() {
+    this.resizeListener = this.recalcFontSize.bind(this);
+  },
   mounted() {
     this.donutEl = this.$refs.donut;
-    this.recalcFontSize();
 
-    this.resizeListener = this.recalcFontSize.bind(this);
-
-    window.addEventListener('resize', this.resizeListener);
+    if (this.autoAdjustTextSize) {
+      this.recalcFontSize();
+      window.addEventListener('resize', this.resizeListener);
+    }
   },
   beforeDestroy() {
     window.removeEventListener('resize', this.resizeListener);

--- a/src/components/site/Demo.vue
+++ b/src/components/site/Demo.vue
@@ -79,6 +79,14 @@
             <textarea name="text" rows="3" v-if="textType === 'HTML'" v-model="donutHTML"></textarea>
           </div>
         </div>
+
+        <div class="control">
+          <label for="auto-adjust-text-size">Auto-adjust font size based on the chart size</label>
+          <input id="auto-adjust-text-size" type="checkbox" v-model="autoAdjustTextSize">
+        </div>
+        <div class="note">
+          Try setting the size to 500px and then check and uncheck this setting to see the difference.
+        </div>
       </div>
       <!-- end donut content -->
 
@@ -188,6 +196,7 @@ export default {
 
       textType: 'HTML',
       donutHTML: `<h1 style="margin: 0;">${initialConsumed}%</h1> donut consumed`,
+      autoAdjustTextSize: true,
 
       unitOptions,
       placementOptions,
@@ -206,7 +215,7 @@ export default {
         size, unit, thickness,
         hasLegend, legendPlacement,
         validatedSections, total,
-        startAngle
+        startAngle, autoAdjustTextSize
       } = this;
       const [computedSize, computedThickness, computedTotal, computedStartAngle] =
         [size, thickness, total, startAngle].map(val => toFixed(val));
@@ -215,6 +224,7 @@ export default {
         size: computedSize > 0 ? computedSize : 200, unit,
         thickness: computedThickness >= 0 && computedThickness <= 100 ? computedThickness : 20,
         hasLegend, legendPlacement,
+        autoAdjustTextSize,
         sections: validatedSections, total: computedTotal > 0 ? computedTotal : 100,
         startAngle: computedStartAngle || 0
       };

--- a/tests/unit/donut.spec.js
+++ b/tests/unit/donut.spec.js
@@ -408,6 +408,10 @@ describe('Donut component', () => {
   });
 
   describe('"auto-adjust-text-size" prop - font-size recalculation for chart content', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
     it('triggers font-size recalculation when the component is mounted', () => {
       const recalcFontSize = jest.fn();
       const wrapper = shallowMount(Donut, { methods: { recalcFontSize } });
@@ -472,7 +476,6 @@ describe('Donut component', () => {
     it('does not perform recalculation when "auto-adjust-text-size" goes from true to false', async () => {
       const removeListener = jest.spyOn(window, 'removeEventListener');
       const wrapper = shallowMount(Donut);
-      jest.spyOn(wrapper.vm.donutEl, 'clientWidth', 'get').mockImplementation(() => 250);
 
       // by default, font size recalc should cause the default value of 1em to change
       await wrapper.vm.$nextTick();
@@ -488,11 +491,11 @@ describe('Donut component', () => {
     it('performs recalculation when "auto-adjust-text-size" goes from false to true', async () => {
       const addListener = jest.spyOn(window, 'addEventListener');
       const wrapper = shallowMount(Donut, { propsData: { autoAdjustTextSize: false } });
-      jest.spyOn(wrapper.vm.donutEl, 'clientWidth', 'get').mockImplementation(() => 250);
 
       // with the prop set to false, even after nextTick, size should remain 1em
       await wrapper.vm.$nextTick();
       expect(wrapper.vm.fontSize).toBe('1em');
+      expect(addListener).not.toHaveBeenCalled();
 
       wrapper.setProps({ autoAdjustTextSize: true });
       await wrapper.vm.$nextTick();

--- a/tests/unit/donut.spec.js
+++ b/tests/unit/donut.spec.js
@@ -407,10 +407,11 @@ describe('Donut component', () => {
     });
   });
 
-  describe('font-size recalculation for chart content', () => {
+  describe('"auto-adjust-text-size" prop - font-size recalculation for chart content', () => {
     it('triggers font-size recalculation when the component is mounted', () => {
       const recalcFontSize = jest.fn();
-      shallowMount(Donut, { methods: { recalcFontSize } });
+      const wrapper = shallowMount(Donut, { methods: { recalcFontSize } });
+      expect(wrapper.vm.autoAdjustTextSize).toBe(true);
       expect(recalcFontSize).toHaveBeenCalledTimes(1);
     });
 
@@ -453,6 +454,53 @@ describe('Donut component', () => {
       const removeListener = jest.spyOn(window, 'removeEventListener');
       wrapper.destroy();
       expect(removeListener).toHaveBeenCalledWith('resize', expect.any(Function));
+    });
+
+    it('does not perform recalculation or set resize listener when "auto-adjust-text-size" is not set', async () => {
+      const recalcFontSize = jest.fn();
+      const addListener = jest.spyOn(window, 'addEventListener');
+      const wrapper = shallowMount(Donut, {
+        propsData: { autoAdjustTextSize: false },
+        methods: { recalcFontSize }
+      });
+
+      await wrapper.vm.$nextTick();
+      expect(recalcFontSize).not.toHaveBeenCalled();
+      expect(addListener).not.toHaveBeenCalled();
+    });
+
+    it('does not perform recalculation when "auto-adjust-text-size" goes from true to false', async () => {
+      const removeListener = jest.spyOn(window, 'removeEventListener');
+      const wrapper = shallowMount(Donut);
+      jest.spyOn(wrapper.vm.donutEl, 'clientWidth', 'get').mockImplementation(() => 250);
+
+      // by default, font size recalc should cause the default value of 1em to change
+      await wrapper.vm.$nextTick();
+      expect(wrapper.vm.fontSize).not.toBe('1em');
+
+      wrapper.setProps({ autoAdjustTextSize: false });
+
+      // setting it to false should set it back to 1em and remove the resize event listener
+      expect(wrapper.vm.fontSize).toBe('1em');
+      expect(removeListener).toHaveBeenCalledWith('resize', expect.any(Function));
+    });
+
+    it('performs recalculation when "auto-adjust-text-size" goes from false to true', async () => {
+      const addListener = jest.spyOn(window, 'addEventListener');
+      const wrapper = shallowMount(Donut, { propsData: { autoAdjustTextSize: false } });
+      jest.spyOn(wrapper.vm.donutEl, 'clientWidth', 'get').mockImplementation(() => 250);
+
+      // with the prop set to false, even after nextTick, size should remain 1em
+      await wrapper.vm.$nextTick();
+      expect(wrapper.vm.fontSize).toBe('1em');
+
+      wrapper.setProps({ autoAdjustTextSize: true });
+      await wrapper.vm.$nextTick();
+
+      // setting it to true should cause the recalculation to trigger immediately
+      expect(wrapper.vm.fontSize).not.toBe('1em');
+      // and it should register the resize listener
+      expect(addListener).toHaveBeenCalledWith('resize', expect.any(Function));
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1248,19 +1248,14 @@ acorn@^3.0.4:
   integrity sha1-ReN/s56No/JbruP/U2niu18iAXo=
 
 acorn@^5.0.0, acorn@^5.5.0, acorn@^5.5.3, acorn@^5.6.2:
-  version "5.7.3"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
-  integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
+  version "5.7.4"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.4.tgz#3e8d8a9947d0599a1796d10225d7432f4a4acf5e"
+  integrity sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==
 
-acorn@^6.0.1:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.3.0.tgz#0087509119ffa4fc0a0041d1e93a417e68cb856e"
-  integrity sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==
-
-acorn@^6.0.7, acorn@^6.1.1:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
-  integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
+acorn@^6.0.1, acorn@^6.0.7, acorn@^6.1.1:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
+  integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
 
 address@^1.0.3:
   version "1.1.0"
@@ -6223,9 +6218,9 @@ minimist@0.0.8:
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
 minimist@^1.1.1, minimist@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
 minimist@~0.0.1:
   version "0.0.10"
@@ -9338,10 +9333,10 @@ vue-style-loader@^4.1.0:
     hash-sum "^1.0.2"
     loader-utils "^1.0.2"
 
-vue-template-compiler@^2.5.17:
-  version "2.6.10"
-  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.6.10.tgz#323b4f3495f04faa3503337a82f5d6507799c9cc"
-  integrity sha512-jVZkw4/I/HT5ZMvRnhv78okGusqe0+qH2A0Em0Cp8aq78+NK9TII263CDVz2QXZsIT+yyV/gZc/j/vlwa+Epyg==
+vue-template-compiler@^2.6.11:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.6.11.tgz#c04704ef8f498b153130018993e56309d4698080"
+  integrity sha512-KIq15bvQDrcCjpGjrAhx4mUlyyHfdmTaoNfeoATHLAiWB+MU3cx4lOzMwrnUh9cCxy0Lt1T11hAFY6TQgroUAA==
   dependencies:
     de-indent "^1.0.2"
     he "^1.1.0"
@@ -9351,10 +9346,10 @@ vue-template-es2015-compiler@^1.6.0, vue-template-es2015-compiler@^1.9.0:
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
-vue@^2.5.17:
-  version "2.6.10"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.10.tgz#a72b1a42a4d82a721ea438d1b6bf55e66195c637"
-  integrity sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ==
+vue@^2.6.11:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.11.tgz#76594d877d4b12234406e84e35275c6d514125c5"
+  integrity sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ==
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This PR implements the following changes:

### Library

- Add `auto-adjust-text-size` boolean prop to enable/disable automatic font size recalculation. (resolves #29)
- Minor refactoring.
- Upgrade to Vue 2.6.11.
- Upgrad some vulnerable dev dependencies.

### Documentation

- Add documentation for `auto-adjust-text-size`.

### Demo

- Add an option to demonstrate `auto-adjust-text-size` on demo page.

### Implementation

Instead of simply `return`ing from the font recalc function, I went with a slightly different approach that takes care of conditionally registering/removing `resize` listener for the chart based on the prop's value.