### PR TITLE
Add Vue version selector and link to documentation for Vue 3

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -8,14 +8,14 @@ on:
 jobs:
   build-deploy:
     name: Build and deploy the demo site to GitHub Pages
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
 
-      - name: Use Node.js 8.15.0
-        uses: actions/setup-node@v1
+      - name: Use Node.js 12
+        uses: actions/setup-node@v2
         with:
-          node-version: 8.15.0
+          node-version: '12'
 
       - run: yarn install
 
@@ -23,11 +23,9 @@ jobs:
         run: yarn build
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v2.4.0
+        uses: peaceiris/actions-gh-pages@v3
         with:
-          emptyCommits: false
-          keepFiles: true
-        env:
-          ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-          PUBLISH_BRANCH: gh-pages
-          PUBLISH_DIR: ./docs
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          keep_files: true
+          publish_branch: gh-pages
+          publish_dir: ./docs

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,14 +3,14 @@ on: [push, pull_request]
 jobs:
   lint_test_upload-coverage:
     name: Lint, test and upload coverage
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
-      - name: Use Node.js 8.15.0
-        uses: actions/setup-node@v1
+      - name: Use Node.js 12
+        uses: actions/setup-node@v2
         with:
-          node-version: 8.15.0
+          node-version: '12'
 
       - run: yarn install
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@
   </a>
 </div>
 
+<hr>
+
+>Using Vue 3? Check out the [documentation for vue-css-donut-chart v2](https://github.com/dumptyd/vue-css-donut-chart/tree/next).
+
 ## Live demo
 
 Live demo can be found on the project page &ndash; https://dumptyd.github.io/vue-css-donut-chart
@@ -37,6 +41,8 @@ Playground &ndash; https://jsfiddle.net/dumptyd/ujvypcd3/
 ## Features
 
 :black_medium_small_square: No external dependencies.
+
+:black_medium_small_square: Vue 2 and Vue 3 support.
 
 :black_medium_small_square: Small size footprint. [![npm bundle size](https://img.shields.io/bundlephobia/minzip/vue-css-donut-chart?style=flat-square)](https://bundlephobia.com/result?p=vue-css-donut-chart)
 
@@ -232,4 +238,4 @@ All the `section-*` listeners are called with the `section` object on which the 
 
 ## License
 
-Code released under [MIT]((https://github.com/vue-css-donut-chart/vue-css-donut-chart/blob/master/LICENSE)) license.
+Code released under [MIT](https://github.com/vue-css-donut-chart/vue-css-donut-chart/blob/master/LICENSE) license.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@vue/test-utils": "1.0.0-beta.29",
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "^23.6.0",
-    "dev": "^0.1.3",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.14.0",
     "vue-template-compiler": "^2.6.11"

--- a/src/components/site/Demo.vue
+++ b/src/components/site/Demo.vue
@@ -2,8 +2,16 @@
 <div class="container">
   <div class="container-header">
     <h1>vue-css-donut-chart <sup>{{ version }}</sup></h1>
-    <span>Lightweight Vue component for drawing pure CSS donut charts</span>
+    <div>
+      Lightweight
+      <select class="vue-version-select" @change="handleVersionSelectChange">
+        <option value="/vue-css-donut-chart" selected>Vue 2</option>
+        <option value="/vue-css-donut-chart/next">Vue 3</option>
+      </select>
+      component for drawing pure CSS donut charts
+    </div>
   </div>
+
   <nav class="container-nav">
     <a href="https://github.com/dumptyd/vue-css-donut-chart/blob/master/README.md">Documentation</a>
     <a href="https://github.com/dumptyd/vue-css-donut-chart/blob/master/README.md#installation">Installation</a>
@@ -11,7 +19,7 @@
     <a href="https://github.com/dumptyd/vue-css-donut-chart">GitHub</a>
   </nav>
   <div class="container-donut">
-    <donut v-on="listeners" v-bind="donutProps">
+    <donut v-bind="donutProps" v-on="listeners">
       <div v-html="donutHTML"></div>
     </donut>
   </div>
@@ -270,6 +278,9 @@ export default {
       ];
       // eslint-disable-next-line no-console
       info.forEach(args => console.log(...args));
+    },
+    handleVersionSelectChange(evt) {
+      window.location.href = evt.target.value;
     }
   },
   components: { Donut }

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -158,3 +158,13 @@ button.outline-red:hover {
     max-height: 300px;
   }
 }
+
+
+.vue-version-select {
+  font-weight: bold;
+  color: #42b883;
+  font-size: .85em;
+  padding: .1em .2em;
+  margin: 0 .2em;
+  border-width: 1px;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1853,13 +1853,6 @@ binary-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
   integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
 
-bindings@^1.3.1:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
-  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
-  dependencies:
-    file-uri-to-path "1.0.0"
-
 bluebird@^3.1.1, bluebird@^3.5.1, bluebird@^3.5.3:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.4.tgz#d6cc661595de30d5b3af5fcedd3c0b3ef6ec5714"
@@ -3116,13 +3109,6 @@ detect-node@^2.0.4:
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
   integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
 
-dev@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/dev/-/dev-0.1.3.tgz#89fdc08705e0e7eaef92d012e26751e4d744322a"
-  integrity sha1-if3AhwXg5+rvktAS4mdR5NdEMio=
-  dependencies:
-    inotify ">= 0.1.6"
-
 diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
@@ -3920,11 +3906,6 @@ file-loader@^3.0.1:
   dependencies:
     loader-utils "^1.0.2"
     schema-utils "^1.0.0"
-
-file-uri-to-path@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
-  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 filename-regex@^2.0.0:
   version "2.0.1"
@@ -4736,14 +4717,6 @@ ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
-
-"inotify@>= 0.1.6":
-  version "1.4.6"
-  resolved "https://registry.yarnpkg.com/inotify/-/inotify-1.4.6.tgz#c5a51852df1647d1a589d46c4baa2771ed36b8d2"
-  integrity sha512-WW8/uqIA04O3AePQVe/Ms3ZLR0yGamaz8YOEpaXc4WBAGOPZfzu58wWErEPSUYaPyDrJRIeCn6PEIQgC1ZyQ5w==
-  dependencies:
-    bindings "^1.3.1"
-    nan "^2.12.1"
 
 inquirer@^3.0.6:
   version "3.3.0"


### PR DESCRIPTION
- Add Vue version selector in the demo site.
- Add a link to Vue 3 documentation from the current one.
- Update workflows to use newer Ubuntu image, actions and node v12.