### PR TITLE
Make Vue a peer dependency in v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.3.0]
+## 1.3.1
+
+- Vue is now listed as a peer dependency rather than a direct one.
+
+## 1.3.0
 
 ### Added
 - `auto-adjust-text-size` prop is here! The prop can be set to `false` to disable the font size recalculation behavior.
@@ -11,7 +15,7 @@ All notable changes to this project will be documented in this file.
 
 - Demo page now has an option to test `auto-adjust-text-size` prop.
 
-## [1.2.0]
+## 1.2.0
 
 ### Added
 
@@ -33,12 +37,12 @@ All notable changes to this project will be documented in this file.
 - Demo page now has a section dedicated for testing all the exposed events.
 - Documentation has been updated with new events.
 
-## [1.1.6]
-## [1.1.5]
+## 1.1.6
+## 1.1.5
 
 - Minor alignment change in documentation so it doesn't look awkward on npm. npm has a bug where it doesn't center align some things.
 
-## [1.1.4]
+## 1.1.4
 
 ### Fixed
 
@@ -51,7 +55,7 @@ All notable changes to this project will be documented in this file.
 - Minor refactoring.
 - Readme has been revamped with better formatting.
 
-## [1.1.3]
+## 1.1.3
 
 ### Fixed
 
@@ -59,7 +63,7 @@ All notable changes to this project will be documented in this file.
 - Font size is now recalculated only when the chart has rendered.
 
 
-## [1.1.2]
+## 1.1.2
 
 ### Added
 
@@ -69,6 +73,6 @@ All notable changes to this project will be documented in this file.
 - Donut component specific `resize` event handler is now removed when the component is destroyed (as it should).
 
 
-## [All versions before 1.1.2]
+## All versions before 1.1.2
 
 - The changelog didn't exist.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@
 
 <hr>
 
->Using Vue 3? Check out the [documentation for vue-css-donut-chart v2](https://github.com/dumptyd/vue-css-donut-chart/tree/next).
+| Using Vue 3? |
+| :- |
+| Check out the [documentation for vue-css-donut-chart v2](https://github.com/dumptyd/vue-css-donut-chart/tree/next). |
+| **NPM** - https://www.npmjs.com/package/vue-css-donut-chart/v/next |
 
 ## Live demo
 

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "main": "dist/vcdonut.umd.js",
   "module": "dist/vcdonut.common.js",
   "unpkg": "dist/vcdonut.umd.min.js",
-  "dependencies": {
-    "vue": "^2.6.11"
+  "peerDependencies": {
+    "vue": "^2"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^3.0.3",
@@ -29,7 +29,8 @@
     "babel-jest": "^23.6.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.14.0",
-    "vue-template-compiler": "^2.6.11"
+    "vue": "^2.6.14",
+    "vue-template-compiler": "^2.6.14"
   },
   "postcss": {
     "plugins": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-css-donut-chart",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Lightweight Vue component for drawing pure CSS donut charts",
   "author": "dumptyd <dumptyd2.0@gmail.com>",
   "homepage": "https://dumptyd.github.io/vue-css-donut-chart/",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9306,10 +9306,10 @@ vue-style-loader@^4.1.0:
     hash-sum "^1.0.2"
     loader-utils "^1.0.2"
 
-vue-template-compiler@^2.6.11:
-  version "2.6.11"
-  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.6.11.tgz#c04704ef8f498b153130018993e56309d4698080"
-  integrity sha512-KIq15bvQDrcCjpGjrAhx4mUlyyHfdmTaoNfeoATHLAiWB+MU3cx4lOzMwrnUh9cCxy0Lt1T11hAFY6TQgroUAA==
+vue-template-compiler@^2.6.14:
+  version "2.6.14"
+  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.6.14.tgz#a2f0e7d985670d42c9c9ee0d044fed7690f4f763"
+  integrity sha512-ODQS1SyMbjKoO1JBJZojSw6FE4qnh9rIpUZn2EUT86FKizx9uH5z6uXiIrm4/Nb/gwxTi/o17ZDEGWAXHvtC7g==
   dependencies:
     de-indent "^1.0.2"
     he "^1.1.0"
@@ -9319,10 +9319,10 @@ vue-template-es2015-compiler@^1.6.0, vue-template-es2015-compiler@^1.9.0:
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
-vue@^2.6.11:
-  version "2.6.11"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.11.tgz#76594d877d4b12234406e84e35275c6d514125c5"
-  integrity sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ==
+vue@^2.6.14:
+  version "2.6.14"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.14.tgz#e51aa5250250d569a3fbad3a8a5a687d6036e235"
+  integrity sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ==
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
- Make Vue a peer dependency in v1.
- Use the latest vue 2 version for local dev.